### PR TITLE
MUZIMA-607: Enhace resolution of potential duplicate registrations

### DIFF
--- a/api/src/main/java/org/openmrs/module/muzima/api/db/hibernate/HibernateErrorDataDao.java
+++ b/api/src/main/java/org/openmrs/module/muzima/api/db/hibernate/HibernateErrorDataDao.java
@@ -13,10 +13,20 @@
  */
 package org.openmrs.module.muzima.api.db.hibernate;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.hibernate.Criteria;
+import org.hibernate.criterion.CriteriaSpecification;
+import org.hibernate.criterion.Disjunction;
+import org.hibernate.criterion.MatchMode;
+import org.hibernate.criterion.Order;
+import org.hibernate.criterion.Projections;
+import org.hibernate.criterion.Restrictions;
 import org.openmrs.module.muzima.api.db.ErrorDataDao;
 import org.openmrs.module.muzima.model.ErrorData;
+
+import java.util.List;
 
 /**
  */
@@ -29,5 +39,66 @@ public class HibernateErrorDataDao extends HibernateDataDao<ErrorData> implement
      */
     protected HibernateErrorDataDao() {
         super(ErrorData.class);
+    }
+
+    /**
+     * Get ErrorData with matching search term for particular page.
+     *
+     * @param search     the search term.
+     * @param pageNumber the page number.
+     * @param pageSize   the size of the page.
+     * @return list of data for the page.
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public List<ErrorData> getPagedData(final String search, final Integer pageNumber, final Integer pageSize) {
+        Criteria criteria = createCriteria(search);
+        if (pageNumber != null) {
+            criteria.setFirstResult((pageNumber - 1) * pageSize);
+        }
+        if (pageSize != null) {
+            criteria.setMaxResults(pageSize);
+        }
+        criteria.addOrder(Order.desc("dateCreated"));
+        return criteria.list();
+    }
+
+    /**
+     * Get the total number of ErrorData with matching search term.
+     *
+     *
+     * @param search the search term.
+     * @return total number of data in the database.
+     */
+    @Override
+    public Number countData(final String search) {
+        Criteria criteria = createCriteria(search);
+        criteria.setProjection(Projections.rowCount());
+        return (Number) criteria.uniqueResult();
+    }
+
+    private Criteria createCriteria(String search) {
+        Criteria criteria = getSessionFactory().getCurrentSession().createCriteria(ErrorData.class);
+        criteria.createAlias("location", "location", CriteriaSpecification.LEFT_JOIN);
+        criteria.createAlias("provider", "provider", CriteriaSpecification.LEFT_JOIN);
+        criteria.createAlias("errorMessages", "errorMessages", CriteriaSpecification.LEFT_JOIN);
+
+        if (StringUtils.isNotEmpty(search)) {
+            Disjunction disjunction = Restrictions.disjunction();
+            disjunction.add(Restrictions.ilike("payload", search, MatchMode.ANYWHERE));
+            disjunction.add(Restrictions.ilike("discriminator", search, MatchMode.ANYWHERE));
+            disjunction.add(Restrictions.ilike("location.name", search, MatchMode.ANYWHERE));
+            disjunction.add(Restrictions.ilike("patientUuid", search, MatchMode.ANYWHERE));
+            disjunction.add(Restrictions.ilike("formName", search, MatchMode.ANYWHERE));
+            disjunction.add(Restrictions.ilike("provider.identifier", search, MatchMode.ANYWHERE));
+            disjunction.add(Restrictions.ilike("provider.name", search, MatchMode.ANYWHERE));
+            disjunction.add(Restrictions.ilike("errorMessages.message", search, MatchMode.ANYWHERE));
+            if(StringUtils.isNumeric(search)) {
+                disjunction.add(Restrictions.eq("location.locationId", Integer.parseInt(search)));
+            }
+            criteria.add(disjunction);
+        }
+
+        return criteria;
     }
 }

--- a/api/src/main/java/org/openmrs/module/muzima/api/service/DataService.java
+++ b/api/src/main/java/org/openmrs/module/muzima/api/service/DataService.java
@@ -10,6 +10,7 @@ import org.openmrs.module.muzima.model.ErrorMessage;
 import org.openmrs.module.muzima.model.NotificationData;
 import org.openmrs.module.muzima.model.QueueData;
 
+import javax.validation.constraints.NotNull;
 import java.util.Date;
 import java.util.List;
 
@@ -468,5 +469,15 @@ public interface DataService extends OpenmrsService {
     List<ErrorMessage> validateData(String uuid, String formData);
 
     List<String> getDiscriminatorTypes();
+
+    /**
+     * For a submitted payload the method fetches the associated ErrorData record, updates its payload with passed UUID whose patient UUID is changed
+     * to reflect the duplicate patient's uuid already in the system. The payload is re-queued with descriminator "json-update-demographics" instead
+     * of the "json-registration". All ErrorData records bearing the patient UUID in error are also fetched updated and re-queued.
+     * @param errorDataUuid String - UUID of ErrorData record with duplicate patient details submitted for registration.
+     * @param formData  String - payload with demographic information to be updated to the existing patient.
+     * @return List of QueueData - A list of newly submitted QueuedData.
+     */
+    List<QueueData> mergeDuplicatePatient(@NotNull final String errorDataUuid, @NotNull final String existingPatientUuid, @NotNull String formData);
 
 }

--- a/api/src/main/java/org/openmrs/module/muzima/handler/JsonRegistrationQueueDataHandler.java
+++ b/api/src/main/java/org/openmrs/module/muzima/handler/JsonRegistrationQueueDataHandler.java
@@ -112,14 +112,16 @@ public class JsonRegistrationQueueDataHandler implements QueueDataHandler {
     }
 
     private void validateUnsavedPatient() {
-        Patient savedPatient = findSimilarSavedPatient();
-        if (savedPatient != null) {
-            queueProcessorException.addException(
-                    new Exception(
-                            "Found a patient with similar characteristic :  patientId = " + savedPatient.getPatientId()
-                                    + " Identifier Id = " + savedPatient.getPatientIdentifier().getIdentifier()
-                    )
-            );
+        if(!JsonUtils.readAsBoolean(payload, "$['skipPatientMatching']")) {
+            Patient savedPatient = findSimilarSavedPatient();
+            if (savedPatient != null) {
+                queueProcessorException.addException(
+                        new Exception(
+                                "Found a patient with similar characteristic :  patientId = " + savedPatient.getPatientId()
+                                        + " Identifier Id = " + savedPatient.getPatientIdentifier().getIdentifier()
+                        )
+                );
+            }
         }
     }
 

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -2,6 +2,7 @@ ${project.parent.artifactId}.title=Muzima
 ${project.parent.artifactId}.view.sources=View Data Source
 ${project.parent.artifactId}.view.queues=View Queue Data
 ${project.parent.artifactId}.view.errors=View Error Data
+${project.parent.artifactId}.view.duplicates=View Potential Duplicates
 ${project.parent.artifactId}.view.settings=View mUzima Settings
 ${project.parent.artifactId}.view.registrations=View Registration
 ${project.parent.artifactId}.form.manage=Muzima Forms

--- a/api/src/test/resources/datasets/DataServiceTest-ErrorData2.xml
+++ b/api/src/test/resources/datasets/DataServiceTest-ErrorData2.xml
@@ -1,0 +1,25 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<dataset>
+    <muzima_error_data id="3" discriminator="json-registration" data_source="1" payload='{"patient":{"patient.uuid":"e3fe8d12-2c4e-4d0d-b405-1b0a7de2aa31","patient.family_name":"Test","patient.given_name":"Patient1","patient.middle_name":"Patient1","patient.mothers_name":"Non","patient.medical_record_number":"333333333-8","patient.other_identifier_type":"KENYAN NATIONAL ID NUMBER","patient.other_identifier_value":"12345678","patient.confirm_identifier_value":"12345678","patient.sex":"M","patient.birth_date":"01-01-1993","patient.birthdate_estimated":"true"},"tmp":{"tmp.birthdate_type":"age","tmp.age_in_years":"25"},"encounter":{"encounter.location_id":"3","encounter.provider_id_select":"admin","encounter.provider_id":"admin","encounter.encounter_datetime":"12-11-2018","encounter.form_uuid":"e72c4bd8-6329-4eb4-b0bd-1c4729ada98e","encounter.user_system_id":"admin"}}'
+                       message="Unable to process queue data" date_processed="2017-09-15 11:28:19"
+                       creator="1" date_created="2017-09-15 11:28:19" form_name="mUzima Registration Form" location="3" provider="1" patient_uuid="e3fe8d12-2c4e-4d0d-b405-1b0a7de2aa31"
+                       uuid="03bd16de-1d9a-44f4-b775-397aabae1dc0"/>
+    <muzima_error_message id="3" muzima_error_data_id="3" message="Found a patient with similar characteristic :  patientId = 1 Identifier Id = 1093-9" creator="1"
+                          date_created="2017-09-15 11:28:20" uuid="03bd16de-1d9a-44f4-b775-397aabae1dc0"/>
+
+    <muzima_error_data id="2" discriminator="json-registration" data_source="1" payload="some payload" message="Unable to process queue data" date_processed="2017-09-18 11:28:19"
+                       creator="1" date_created="2017-09-18 11:28:19" form_name="mUzima Registration Form" location="3" provider="1" patient_uuid="5b5e1658-ff6f-45f8-842a-ae92d91e58f8"
+                       uuid="03bd16y7-1d9a-44f4-b775-397aabae1dc0"/>
+    <muzima_error_message id="2" muzima_error_data_id="2" message="'Patient#null' failed to validate with reason: Identifier 111111111-6 already in use by another patient" creator="1"
+                          date_created="2017-09-18 11:28:20" uuid="08c56375-93b2-4853-a030-b2cb04f12a08"/>
+
+    <muzima_error_data id="4" discriminator="json-encounter" data_source="1" payload='{"patient":{"patient.uuid":"e3fe8d12-2c4e-4d0d-b405-1b0a7de2aa31","patient.family_name":"Cherwon","patient.given_name":"Mitchell","patient.middle_name":"Yebei","patient.sex":"F","patient.birth_date":"05-09-1978"},"encounter":{"encounter.location_id":"3","encounter.provider_id_select":"5-9","encounter.provider_id":"5-9","encounter.encounter_datetime":"06-11-2018","encounter.form_uuid":"5d7bf964-2300-4280-b007-a6a1c31c9e79","encounter.user_system_id":"admin"},"observation":{"1839^CURRENT VISIT TYPE^99DCT":"2345^FOLLOW-UP^99DCT","5624^GRAVIDA^99DCT":"2","1053^PARITY^99DCT":"3","2061^MENSTRUATION STATUS^99DCT":"5989^MENSTRUATING^99DCT","1836^LAST MENSTRUAL PERIOD DATE^99DCT":"06-11-2018","8351^PREGNANCY STATUS, CODED^99DCT":"1066^NO^99DCT","5596^ESTIMATED DATE OF CONFINEMENT^99DCT":"06-11-2018","9733^REASON NOT PREGNANT^99DCT":"9729^PREGNANCY NOT SUSPECTED^99DCT","6709^HIV STATUS^99DCT":"664^NEGATIVE^99DCT","856^HIV VIRAL LOAD, QUANTITATIVE^99DCT":"3","9589^PATIENT REPORTED PAST VISUAL INSPECTION WITH ACETIC ACID TEST^99DCT":"1065^YES^99DCT","7381^MOST RECENT VISUAL INSPECTION WITH ACETIC ACID RESULT^99DCT":"703^POSITIVE^99DCT","9590^VIA TEST RESULT THIS VISIT^99DCT":"7293^ULCER^99DCT","7484^VISUAL CERVICAL EXAM FINDINGS^99DCT":"1115^NORMAL^99DCT","7490^VISUAL VAGINAL EXAM FINDINGS^99DCT":"1447^WARTS, GENITAL^99DCT","7487^VISUAL VULVAL EXAM FINDINGS^99DCT":"1115^NORMAL^99DCT","7479^PROCEDURES DONE THIS VISIT^99DCT":"1107^NONE^99DCT","7500^GYNECOLOGIC ONCOLOGY PLAN^99DCT":"9725^RETURN FOR RESULT^99DCT","7222^THERAPEUTIC PLAN NOTES^99DCT":"Okay","5096^RETURN VISIT DATE^99DCT":"06-11-2018"}}'
+                       message="Unable to process queue data" date_processed="2017-09-18 11:28:19"
+                       creator="1" date_created="2017-09-20 12:30:19" form_name="Muzima Encounter Form" location="3" provider="1" patient_uuid="e3fe8d12-2c4e-4d0d-b405-1b0a7de2aa31"
+                       uuid="43794a2a-dc3c-451d-8e73-937fee85754e"/>
+    <muzima_error_message id="4" muzima_error_data_id="4" message="1458 : Unable to find Concept for Question with ID: 2061" creator="1"
+                          date_created="2017-09-18 11:28:20" uuid="9e92eb07-3d88-4531-a875-b68881f80a5d"/>
+    <muzima_error_message id="5" muzima_error_data_id="4" message="1460 : Unable to find Concept for Question with ID: 7484" creator="1"
+                          date_created="2017-09-18 11:28:20" uuid="98ae3171-c583-4f1d-95e1-55ec183213a8"/>
+</dataset>
+

--- a/omod/src/main/java/org/openmrs/module/muzima/extension/html/AdminList.java
+++ b/omod/src/main/java/org/openmrs/module/muzima/extension/html/AdminList.java
@@ -54,6 +54,7 @@ public class AdminList extends AdministrationSectionExt {
         map.put("/module/muzimacore/view.list#/registrations", "muzimacore.view.registrations");
         map.put("/module/muzimacore/view.list#/forms", "muzimacore.form.manage");
         map.put("/module/muzimacore/view.list#/errors", "muzimacore.view.errors");
+        map.put("/module/muzimacore/view.list#/duplicates", "muzimacore.view.duplicates");
         map.put("/module/muzimacore/view.list#/settings", "muzimacore.view.settings");
         map.put("/module/muzimacore/view.list#/cohortDefinitions", "muzimacore.view.cohortdefinition");
         return map;

--- a/omod/src/main/java/org/openmrs/module/muzima/web/controller/ErrorController.java
+++ b/omod/src/main/java/org/openmrs/module/muzima/web/controller/ErrorController.java
@@ -17,11 +17,14 @@ import org.openmrs.api.context.Context;
 import org.openmrs.module.muzima.api.service.DataService;
 import org.openmrs.module.muzima.model.ErrorData;
 import org.openmrs.module.muzima.model.ErrorMessage;
+import org.openmrs.module.muzima.model.QueueData;
 import org.openmrs.module.muzima.web.utils.WebConverter;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -29,10 +32,9 @@ import java.util.Map;
  * TODO: Write brief description about the class here.
  */
 @Controller
-@RequestMapping(value = "/module/muzimacore/error.json")
 public class ErrorController {
 
-    @RequestMapping(method = RequestMethod.GET)
+    @RequestMapping(value = "/module/muzimacore/error.json", method = RequestMethod.GET)
     @ResponseBody
     public Map<String, Object> getError(final @RequestParam(value = "uuid") String uuid) {
         ErrorData errorData = null;
@@ -43,7 +45,7 @@ public class ErrorController {
         return WebConverter.convertErrorData(errorData);
     }
 
-    @RequestMapping(method = RequestMethod.POST)
+    @RequestMapping(value = "/module/muzimacore/error.json", method = RequestMethod.POST)
     public Map<String, Object> saveEditedFormData(final @RequestParam(value = "uuid") String uuid,
                                    final @RequestBody String formData){
         ErrorData errorData = null;
@@ -56,5 +58,64 @@ public class ErrorController {
             errorData = dataService.saveErrorData(errorDataEdited);
         }
         return WebConverter.convertErrorData(errorData);
+    }
+
+    @RequestMapping(value = "/module/muzimacore/mergePatient.json", method = RequestMethod.POST)
+    public Map<String, Object> mergePatient(final @RequestBody Map<String, String> data) {
+        Map<String, Object> map = new LinkedHashMap<String, Object>();
+        map.put("results", new ArrayList<Map<String, Object>>());
+
+        if(Context.isAuthenticated()) {
+            String errorDataUuid = data.get("errorDataUuid");
+            String patientUuid = data.get("existingPatientUuid");
+            String formData = data.get("payload");
+            DataService dataService = Context.getService(DataService.class);
+            List<QueueData> queuedData = dataService.mergeDuplicatePatient(errorDataUuid, patientUuid, formData);
+            map.put("results", convertQueueDatas(queuedData));
+        }
+        return map;
+    }
+
+    @RequestMapping(value = "/module/muzimacore/requeueDuplicatePatient.json", method = RequestMethod.POST)
+    public Map<String, Object> createNewAndRequeueAssociatedErroredData(final @RequestBody Map<String, String> data) {
+        Map<String, Object> map = new LinkedHashMap<String, Object>();
+        map.put("results", new ArrayList<Map<String, Object>>());
+        if(Context.isAuthenticated()) {
+            String errorDataUuid = data.get("errorDataUuid");
+            String modifiedPayload = data.get("payload");
+            DataService dataService = Context.getService(DataService.class);
+            ErrorData toRequeue = dataService.getErrorDataByUuid(errorDataUuid);
+            String submittedPatientUuid = toRequeue.getPatientUuid();
+            List<QueueData> queueDataList = new ArrayList<QueueData>();
+            toRequeue.setPayload(modifiedPayload);
+            QueueData queueData = dataService.saveQueueData(new QueueData(toRequeue));
+            queueDataList.add(queueData);
+            dataService.purgeErrorData(toRequeue);
+
+            List<ErrorData> toRequeueErrors = getErrorDataWithAPatientUuid(submittedPatientUuid);
+            for(ErrorData errorData: toRequeueErrors) {
+                queueData = dataService.saveQueueData(new QueueData(errorData));
+                dataService.purgeErrorData(errorData);
+                queueDataList.add(queueData);
+            }
+            map.put("results", convertQueueDatas(queueDataList));
+        }
+        return map;
+
+    }
+
+    private List<Map<String, Object>> convertQueueDatas(final List<QueueData> queueDatas) {
+        List<Map<String, Object>> converted = new ArrayList<Map<String, Object>>();
+        for(QueueData queueData: queueDatas) {
+            converted.add(WebConverter.convertQueueData(queueData));
+        }
+        return converted;
+    }
+
+    private List<ErrorData> getErrorDataWithAPatientUuid(final String patientUuid) {
+        // Fetch all ErrorData associated with the patient UUID (the one determined to be of a duplicate patient).
+        DataService dataService = Context.getService(DataService.class);
+        int countOfErrors = dataService.countErrorData(patientUuid).intValue();
+        return dataService.getPagedErrorData(patientUuid, 1, countOfErrors);
     }
 }

--- a/omod/src/main/webapp/resources/js/custom/app.js
+++ b/omod/src/main/webapp/resources/js/custom/app.js
@@ -20,6 +20,8 @@ muzimaCoreModule.
             when('/update/forms/:muzimaform_uuid',{controller: UpdateCtrl, templateUrl: '../../moduleResources/muzimacore/partials/update/forms.html'}).
             when('/error/:uuid', {controller: ErrorCtrl, templateUrl: '../../moduleResources/muzimacore/partials/error.html'}).
             when('/errors', {controller: ErrorsCtrl, templateUrl: '../../moduleResources/muzimacore/partials/errors.html'}).
+            when('/duplicates', {controller: PotentialDuplicatesErrorsCtrl, templateUrl: '../../moduleResources/muzimacore/partials/potential_duplicates.html'}).
+            when('/merge/:uuid', {controller: MergeCtrl, templateUrl: '../../moduleResources/muzimacore/partials/merge.html'}).
             when('/edit/:uuid', {controller: EditCtrl, templateUrl: '../../moduleResources/muzimacore/partials/edit.html'}).
             when('/setting/:uuid', {controller: SettingCtrl, templateUrl: '../../moduleResources/muzimacore/partials/setting.html'}).
             when('/settings', {controller: SettingsCtrl, templateUrl: '../../moduleResources/muzimacore/partials/settings.html'}).
@@ -90,6 +92,17 @@ muzimaCoreModule.factory('$data', function ($http) {
         return $http.post("error.json?uuid="+uuid,formData);
     };
 
+    var mergePatient = function(info) {
+        return $http.post('mergePatient.json', info);
+    };
+
+    var requeueDuplicatePatient = function(info) {
+        return $http.post('requeueDuplicatePatient.json', info);
+    };
+
+    var getPatientByIdentifier = function (identifier) {
+        return $http.get('../../ws/rest/v1/patient?identifier=' + identifier + "&v=full");
+    };
     return {
         getQueues: getQueues,
         getQueue: getQueue,
@@ -107,8 +120,12 @@ muzimaCoreModule.factory('$data', function ($http) {
 
         getEdit: getEdit,
         editErrors: editErrors,
-        validateData: validateData
-    }
+        validateData: validateData,
+
+        getPatientByIdentifier: getPatientByIdentifier,
+        mergePatient: mergePatient,
+        requeueDuplicatePatient: requeueDuplicatePatient
+    };
 });
 
 muzimaCoreModule.factory('FormService', function ($http) {

--- a/omod/src/main/webapp/resources/js/custom/controllers/ErrorController.js
+++ b/omod/src/main/webapp/resources/js/custom/controllers/ErrorController.js
@@ -248,3 +248,46 @@ function ErrorsCtrl($scope, $location, $data) {
         }
     }, true);
 }
+
+function PotentialDuplicatesErrorsCtrl($scope, $data) {
+    // initialize selected error data for re-queueing
+    $scope.selected = {};
+    // initialize the paging structure
+    $scope.maxSize = 10;
+    $scope.pageSize = 10;
+    $scope.currentPage = 1;
+    $scope.totalItems = 0;
+    var searchTerm = 'Found a patient with similar characteristic';
+    $data.getErrors(searchTerm, $scope.currentPage, $scope.pageSize).then(function (response) {
+        var serverData = response.data;
+        $scope.errors = serverData.objects;
+        $scope.totalItems = serverData.totalItems;
+        $('#wait').hide();
+    }).catch(function(err) {
+        console.log(err);
+        $('#wait').hide();
+    });
+
+    $scope.$watch('currentPage', function (newValue, oldValue) {
+        if (newValue != oldValue) {
+            $data.getErrors($scope.search, $scope.currentPage, $scope.pageSize).
+            then(function (response) {
+                var serverData = response.data;
+                $scope.errors = serverData.objects;
+                $scope.totalItems = serverData.totalItems;
+            });
+        }
+    }, true);
+
+    $scope.$watch('search', function (newValue, oldValue) {
+        if (newValue != oldValue) {
+            $scope.currentPage = 1;
+            $data.getErrors($scope.search, $scope.currentPage, $scope.pageSize).
+            then(function (response) {
+                var serverData = response.data;
+                $scope.errors = serverData.objects;
+                $scope.totalItems = serverData.totalItems;
+            });
+        }
+    }, true);
+}

--- a/omod/src/main/webapp/resources/js/custom/directives/sideNav.js
+++ b/omod/src/main/webapp/resources/js/custom/directives/sideNav.js
@@ -1,0 +1,9 @@
+muzimaCoreModule.directive("sideNavigation", function () {
+    return {
+        restrict: 'E',
+        scope: {
+            menuItem: '@'
+        },
+        templateUrl: '../../moduleResources/muzimacore/partials/directives/_side_nav.html'
+    };
+});

--- a/omod/src/main/webapp/resources/partials/cohortdefinition.html
+++ b/omod/src/main/webapp/resources/partials/cohortdefinition.html
@@ -1,16 +1,5 @@
 <div id="wide-sidebar" class="row">
-    <div class="col-lg-2">
-        <ul class="nav nav-tabs nav-stacked">
-            <li><a href="#/sources">Data Source</a></li>
-            <li><a href="#/configs">Setup Configurations</a></li>
-            <li><a href="#/queues">Queue Data</a></li>
-            <li><a href="#/registrations">Registrations</a></li>
-            <li><a href="#/forms">Muzima Forms</a></li>
-            <li><a href="#/errors">Error Data</a></li>
-            <li><a href="#/settings">Settings</a></li>
-            <li class="navigation-active"><a href="#/cohortDefinitions">Cohort Definitions</a></li>
-        </ul>
-    </div>
+    <side-navigation menu-item="cohortDefinition"></side-navigation>
     <div class="col-lg-8">
         <div ng-switch="mode">
             <div ng-switch-when="view">

--- a/omod/src/main/webapp/resources/partials/cohortdefinitions.html
+++ b/omod/src/main/webapp/resources/partials/cohortdefinitions.html
@@ -1,16 +1,5 @@
 <div id="wide-sidebar" class="row">
-    <div class="col-lg-2">
-        <ul class="nav nav-tabs nav-stacked">
-            <li><a href="#/sources">Data Source</a></li>
-            <li><a href="#/configs">Setup Configurations</a></li>
-            <li><a href="#/queues">Queue Data</a></li>
-            <li><a href="#/registrations">Registrations</a></li>
-            <li><a href="#/forms">Muzima Forms</a></li>
-            <li><a href="#/errors">Error Data</a></li>
-            <li><a href="#/settings">Settings</a></li>
-            <li class="navigation-active"><a href="#/cohortDefinitions">Cohort Definitions</a></li>
-        </ul>
-    </div>
+    <side-navigation menu-item="cohortDefinitions"></side-navigation>
     <div class="col-lg-8">
         <div class="clearfix">
             <div class="row">

--- a/omod/src/main/webapp/resources/partials/config.html
+++ b/omod/src/main/webapp/resources/partials/config.html
@@ -1,16 +1,5 @@
 <div id="wide-sidebar" class="row">
-    <div class="col-lg-2">
-        <ul class="nav nav-tabs nav-stacked">
-            <li><a href="#/sources">Data Source</a></li>
-            <li class="navigation-active"><a href="#/configs">Setup Configuration</a></li>
-            <li><a href="#/queues">Queue Data</a></li>
-            <li><a href="#/registrations">Registrations</a></li>
-            <li><a href="#/forms">Muzima Forms</a></li>
-            <li><a href="#/errors">Error Data</a></li>
-            <li><a href="#/settings">Settings</a></li>
-            <li><a href="#/cohortDefinitions">Cohort Definitions</a></li>
-        </ul>
-    </div>
+    <side-navigation menu-item="config"></side-navigation>
     <div class="col-lg-8">
         <div ng-switch="mode">
             <div ng-switch-when="view">

--- a/omod/src/main/webapp/resources/partials/configs.html
+++ b/omod/src/main/webapp/resources/partials/configs.html
@@ -1,16 +1,5 @@
 <div id="wide-sidebar" class="row">
-    <div class="col-lg-2">
-        <ul class="nav nav-tabs nav-stacked">
-            <li><a href="#/sources">Data Source</a></li>
-            <li class="navigation-active"><a href="#/configs">Setup Configurations</a></li>
-            <li><a href="#/queues">Queue Data</a></li>
-            <li><a href="#/registrations">Registrations</a></li>
-            <li><a href="#/forms">Muzima Forms</a></li>
-            <li><a href="#/errors">Error Data</a></li>
-            <li><a href="#/settings">Settings</a></li>
-            <li><a href="#/cohortDefinitions">Cohort Definitions</a></li>
-        </ul>
-    </div>
+    <side-navigation menu-item="configs"></side-navigation>
     <div class="col-lg-8">
         <div class="clearfix">
             <div class="row">

--- a/omod/src/main/webapp/resources/partials/directives/_side_nav.html
+++ b/omod/src/main/webapp/resources/partials/directives/_side_nav.html
@@ -1,0 +1,13 @@
+<div class="col-lg-2">
+    <ul class="nav nav-tabs nav-stacked">
+        <li ng-class="{'navigation-active': menuItem === 'sources' || menuItem === 'source'}"><a href="#/sources">Data Source</a></li>
+        <li ng-class="{'navigation-active': menuItem === 'configs' || menuItem === 'config'}"><a href="#/configs">Setup Configurations</a></li>
+        <li ng-class="{'navigation-active': menuItem === 'queues' || menuItem === 'queue'}"><a href="#/queues">Queue Data</a></li>
+        <li ng-class="{'navigation-active': menuItem === 'registrations' || menuItem === 'registration'}"><a href="#/registrations">Registrations</a></li>
+        <li ng-class="{'navigation-active': menuItem === 'forms'}"><a href="#/forms">Muzima Forms</a></li>
+        <li ng-class="{'navigation-active': menuItem === 'errors' || menuItem === 'error'}"><a href="#/errors">Error Data</a></li>
+        <li ng-class="{'navigation-active': menuItem === 'duplicates' || menuItem === 'duplicate'}"><a href="#/duplicates">Potential Duplicates</a></li>
+        <li ng-class="{'navigation-active': menuItem === 'settings' || menuItem === 'setting'}"><a href="#/settings">Settings</a></li>
+        <li ng-class="{'navigation-active': menuItem === 'cohortDefinitions' || menuItem === 'cohortDefinition'}"><a href="#/cohortDefinitions">Cohort Definitions</a></li>
+    </ul>
+</div>

--- a/omod/src/main/webapp/resources/partials/edit.html
+++ b/omod/src/main/webapp/resources/partials/edit.html
@@ -1,16 +1,5 @@
 <div id="wide-sidebar" class="row">
-    <div class="col-lg-2">
-        <ul class="nav nav-tabs nav-stacked">
-            <li><a href="#/sources">Data Source</a></li>
-            <li><a href="#/configs">Setup Configurations</a></li>
-            <li><a href="#/queues">Queue Data</a></li>
-            <li><a href="#/registrations">Registrations</a></li>
-            <li><a href="#/forms">Muzima Forms</a></li>
-            <li class="navigation-active"><a href="#/errors">Error Data</a></li>
-            <li><a href="#/settings">Settings</a></li>
-            <li><a href="#/cohortDefinitions">Cohort Definitions</a></li>
-        </ul>
-    </div>
+    <side-navigation menu-item="errors"></side-navigation>
     <div class="col-lg-8">
 
         <form name="registrationForm" ng-controller="EditCtrl" ng-submit="postEditErrors(registrationForm.$valid)">

--- a/omod/src/main/webapp/resources/partials/error.html
+++ b/omod/src/main/webapp/resources/partials/error.html
@@ -1,16 +1,5 @@
 <div id="wide-sidebar" class="row">
-    <div class="col-lg-2">
-        <ul class="nav nav-tabs nav-stacked">
-            <li><a href="#/sources">Data Source</a></li>
-            <li><a href="#/configs">Setup Configurations</a></li>
-            <li><a href="#/queues">Queue Data</a></li>
-            <li><a href="#/registrations">Registrations</a></li>
-            <li><a href="#/forms">Muzima Forms</a></li>
-            <li class="navigation-active"><a href="#/errors">Error Data</a></li>
-            <li><a href="#/settings">Settings</a></li>
-            <li><a href="#/cohortDefinitions">Cohort Definitions</a></li>
-        </ul>
-    </div>
+    <side-navigation menu-item="error"></side-navigation>
     <div class="col-lg-8">
         <table class="table">
             <tbody>

--- a/omod/src/main/webapp/resources/partials/forms.html
+++ b/omod/src/main/webapp/resources/partials/forms.html
@@ -1,16 +1,5 @@
 <div id="wide-sidebar" class="row" ng-init="init()">
-    <div class="col-lg-2">
-        <ul class="nav nav-tabs nav-stacked">
-            <li><a href="#/sources">Data Source</a></li>
-            <li><a href="#/configs">Setup Configurations</a></li>
-            <li><a href="#/queues">Queue Data</a></li>
-            <li><a href="#/registrations">Registrations</a></li>
-            <li class="navigation-active"><a href="#/forms">Muzima Forms</a></li>
-            <li><a href="#/errors">Error Data</a></li>
-            <li><a href="#/settings">Settings</a></li>
-            <li><a href="#/cohortDefinitions">Cohort Definitions</a></li>
-        </ul>
-    </div>
+    <side-navigation menu-item="forms"></side-navigation>
     <div class="col-lg-9">
         <div class="clearfix">
             <div class="row navbar navbar-inverse navbar-custom">

--- a/omod/src/main/webapp/resources/partials/merge.html
+++ b/omod/src/main/webapp/resources/partials/merge.html
@@ -1,0 +1,104 @@
+<div id="wide-sidebar" class="row">
+    <side-navigation menu-item="duplicates"></side-navigation>
+    <div class="col-lg-8">
+        <div class="row">
+            <div class="col-lg-1">
+                <a href="#/duplicates"><button class="btn btn-default">Back</button></a>
+            </div>
+            <div class="col-lg-10"></div>
+            <div class="col-lg-1">
+                <!--<button class="btn btn-default" type="submit">Extend View</button>-->
+            </div>
+        </div>
+        <div class="row">
+            <div class="col-lg-6">
+                <div class="checkbox pull-right">
+                    <label>
+                        <input ng-model="emr_checkbox.select_all" type="checkbox" ng-change="toggleCheckboxes('emr')"> Select All
+                    </label>
+                </div>
+            </div>
+            <div class="col-lg-6">
+                <div class="checkbox">
+                    <label>
+                        <input type="checkbox" ng-model="queue_checkbox.select_all" ng-change="toggleCheckboxes('queue')"> Select All
+                    </label>
+                </div>
+            </div>
+        </div>
+        <div class="row">
+            <div class="col-lg-6">
+                <strong>Existing Record</strong>
+            </div>
+            <div class="col-lg-6">
+                <strong>Queue Record</strong>
+            </div>
+        </div>
+
+        <div class="row" ng-repeat="rowData in tableData">
+            <div class="col-lg-6">
+                <div class="form-group">
+                    <label class="col-md-4">{{rowData.label}}</label>
+                    <div class="col-md-7" ng-class="{ 'has-error': rowData.isConflict }">
+                        <input type="text" class="form-control" ng-model="rowData.emrPatient" disabled>
+                    </div>
+                    <div class="col-md-1">
+                        <div class="checkbox" ng-show="rowData.isConflict">
+                            <label>
+                                <input ng-model="emr_checkbox[rowData.key]" type="checkbox" value="option1" aria-label="..."
+                                       ng-change="toggleIndividualCheckbox('emr',rowData.key)">
+                            </label>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="col-lg-6">
+                <div class="form-group">
+                    <div class="col-md-1">
+                        <div class="checkbox" ng-show="rowData.isConflict">
+                            <label>
+                                <input ng-model="queue_checkbox[rowData.key]" type="checkbox" value="option1" aria-label="..." ng-change="toggleIndividualCheckbox('queue',rowData.key)">
+                            </label>
+                        </div>
+                    </div>
+                    <label class="col-md-4">{{rowData.label}}</label>
+                    <div class="col-md-7" ng-class="{ 'has-error': rowData.isConflict }">
+                        <input type="text" id="queue_{{rowData}}" class="form-control" ng-model="rowData.queuePatient" ng-change="updatePage(rowData)">
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="row">
+            <div class="col-lg-6">
+                <button class="btn btn-primary btn-block" ng-click="mergeDemographics()">MERGE AND REQUEUE</button>
+            </div>
+            <div class="col-lg-6">
+                <button class="btn btn-primary btn-block" ng-click="createAndRequeue()">CREATE AND REQUEUE</button>
+            </div>
+        </div>
+    </div>
+
+    <div id='wait' class='loader'>
+        &nbsp;
+    </div>
+
+    <!-- Modal -->
+    <div class="modal fade" id="merge-modal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true" >
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                    <h4 class="modal-title" id="myModalLabel">Error!</h4>
+                </div>
+                <div class="modal-body text-danger">
+                    {{ popupMessage }}
+                </div>
+                <div class="modal-footer">
+                    <button id = "btnNo" type="button" class="btn btn-primary" data-dismiss="modal">Ok</button>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+</div>

--- a/omod/src/main/webapp/resources/partials/potential_duplicates.html
+++ b/omod/src/main/webapp/resources/partials/potential_duplicates.html
@@ -1,5 +1,5 @@
 <div id="wide-sidebar" class="row">
-    <side-navigation menu-item="errors"></side-navigation>
+    <side-navigation menu-item="duplicates"></side-navigation>
     <div class="col-lg-8">
         <div class="clearfix">
             <div class="row">
@@ -11,8 +11,7 @@
                 <table class="table table-striped table-bordered table-hover">
                     <thead>
                     <tr>
-                        <th>&nbsp;</th>
-                        <th>#</th>
+                        <th>Examine</th>
                         <th>Provider</th>
                         <th>Location</th>
                         <th>Form Name</th>
@@ -24,14 +23,10 @@
                     </thead>
                     <tbody>
                     <tr ng-hide="errors.length">
-                        <td colspan="9">Hooray! You have no errors here.</td>
+                        <td colspan="8">Hooray! You have no errors here.</td>
                     </tr>
                     <tr ng-repeat="error in errors | orderBy:'submitted':true">
-                        <td>
-                            <input type="checkbox" value="{{error.uuid}}"
-                                   ng-checked="selected[error.uuid]" ng-model="selected[error.uuid]">
-                        </td>
-                        <td><a href="#/error/{{error.uuid}}"  style="text-decoration: none"><i class=icon-edit icon-edit></i></a></td>
+                        <td><a href="#/merge/{{error.uuid}}"  style="text-decoration: none"><i class=icon-edit icon-edit></i></a></td>
                         <td>{{error.providerId}} - {{error.providerName}}</td>
                         <td>{{error.locationId}} - {{error.locationName}}</td>
                         <td>{{error.formName}}</td>
@@ -43,10 +38,10 @@
                     </tbody>
                 </table>
             </div>
-            <div ng-show="errors.length" class="row col-lg-12">
-                <button type="submit" ng-click="queue()" class="btn btn-primary" style="margin-top: 20px">Queue</button>
-                <ul uib-pagination total-items="totalItems" ng-model="currentPage" max-size="maxSize" items-per-page="pageSize" boundary-links="true" force-ellipses="true" class="pull-right"></ul>
-            </div>
         </div>
+    </div>
+
+    <div id='wait' class='loader'>
+        &nbsp;
     </div>
 </div>

--- a/omod/src/main/webapp/resources/partials/queue.html
+++ b/omod/src/main/webapp/resources/partials/queue.html
@@ -1,15 +1,5 @@
 <div id="wide-sidebar" class="row">
-    <div class="col-lg-2">
-        <ul class="nav nav-tabs nav-stacked">
-            <li><a href="#/sources">Data Source</a></li>
-            <li><a href="#/configs">Setup Configurations</a></li>
-            <li class="navigation-active"><a href="#/queues">Queue Data</a></li>
-            <li><a href="#/registrations">Registrations</a></li>
-            <li><a href="#/forms">Muzima Forms</a></li>
-            <li><a href="#/errors">Error Data</a></li>
-            <li><a href="#/cohortDefinitions">Cohort Definitions</a></li>
-        </ul>
-    </div>
+    <side-navigation menu-item="queue"></side-navigation>
     <div class="col-lg-8">
         <table class="table">
             <tbody>

--- a/omod/src/main/webapp/resources/partials/queues.html
+++ b/omod/src/main/webapp/resources/partials/queues.html
@@ -1,16 +1,5 @@
 <div id="wide-sidebar" class="row">
-    <div class="col-lg-2">
-        <ul class="nav nav-tabs nav-stacked">
-            <li><a href="#/sources">Data Source</a></li>
-            <li><a href="#/configs">Setup Configurations</a></li>
-            <li class="navigation-active"><a href="#/queues">Queue Data</a></li>
-            <li><a href="#/registrations">Registrations</a></li>
-            <li><a href="#/forms">Muzima Forms</a></li>
-            <li><a href="#/errors">Error Data</a></li>
-            <li><a href="#/settings">Settings</a></li>
-            <li><a href="#/cohortDefinitions">Cohort Definitions</a></li>
-        </ul>
-    </div>
+    <side-navigation menu-item="queues"></side-navigation>
     <div class="col-lg-8">
         <div class="clearfix">
             <div class="row">

--- a/omod/src/main/webapp/resources/partials/registration.html
+++ b/omod/src/main/webapp/resources/partials/registration.html
@@ -1,16 +1,5 @@
 <div id="wide-sidebar" class="row">
-    <div class="col-lg-2">
-        <ul class="nav nav-tabs nav-stacked">
-            <li><a href="#/sources">Data Source</a></li>
-            <li><a href="#/configs">Setup Configurations</a></li>
-            <li><a href="#/queues">Queue Data</a></li>
-            <li class="navigation-active"><a href="#/registrations">Registrations</a></li>
-            <li><a href="#/forms">Muzima Forms</a></li>
-            <li><a href="#/errors">Error Data</a></li>
-            <li><a href="#/settings">Settings</a></li>
-            <li><a href="#/cohortDefinitions">Cohort Definitions</a></li>
-        </ul>
-    </div>
+    <side-navigation menu-item="registration"></side-navigation>
     <div class="col-lg-12">
         <table class="table table-striped table-bordered table-condensed table-hover">
             <tbody>

--- a/omod/src/main/webapp/resources/partials/registrations.html
+++ b/omod/src/main/webapp/resources/partials/registrations.html
@@ -1,16 +1,5 @@
 <div id="wide-sidebar" class="row">
-    <div class="col-lg-2">
-        <ul class="nav nav-tabs nav-stacked">
-            <li><a href="#/sources">Data Source</a></li>
-            <li><a href="#/configs">Setup Configurations</a></li>
-            <li><a href="#/queues">Queue Data</a></li>
-            <li class="navigation-active"><a href="#/registrations">Registrations</a></li>
-            <li><a href="#/forms">Muzima Forms</a></li>
-            <li><a href="#/errors">Error Data</a></li>
-            <li><a href="#/settings">Settings</a></li>
-            <li><a href="#/cohortDefinitions">Cohort Definitions</a></li>
-        </ul>
-    </div>
+    <side-navigation menu-item="registrations"></side-navigation>
     <div class="col-lg-8">
         <div class="clearfix">
             <div class="row">

--- a/omod/src/main/webapp/resources/partials/setting.html
+++ b/omod/src/main/webapp/resources/partials/setting.html
@@ -1,16 +1,5 @@
 <div id="wide-sidebar" class="row">
-    <div class="col-lg-2">
-        <ul class="nav nav-tabs nav-stacked">
-            <li><a href="#/sources">Data Source</a></li>
-            <li><a href="#/configs">Setup Configurations</a></li>
-            <li><a href="#/queues">Queue Data</a></li>
-            <li><a href="#/registrations">Registrations</a></li>
-            <li><a href="#/forms">Muzima Forms</a></li>
-            <li><a href="#/errors">Error Data</a></li>
-            <li class="navigation-active"><a href="#/settings">Settings</a></li>
-            <li><a href="#/cohortDefinitions">Cohort Definitions</a></li>
-        </ul>
-    </div>
+    <side-navigation menu-item="setting"></side-navigation>
     <div class="col-lg-8">
         <div ng-switch="mode">
             <div ng-switch-when="view">

--- a/omod/src/main/webapp/resources/partials/settings.html
+++ b/omod/src/main/webapp/resources/partials/settings.html
@@ -1,16 +1,5 @@
 <div id="wide-sidebar" class="row">
-    <div class="col-lg-2">
-        <ul class="nav nav-tabs nav-stacked">
-            <li><a href="#/sources">Data Source</a></li>
-            <li><a href="#/configs">Setup Configurations</a></li>
-            <li><a href="#/queues">Queue Data</a></li>
-            <li><a href="#/registrations">Registrations</a></li>
-            <li><a href="#/forms">Muzima Forms</a></li>
-            <li><a href="#/errors">Error Data</a></li>
-            <li class="navigation-active"><a href="#/settings">Settings</a></li>
-            <li><a href="#/cohortDefinitions">Cohort Definitions</a></li>
-        </ul>
-    </div>
+    <side-navigation menu-item="settings"></side-navigation>
     <div class="col-lg-8">
         <div class="clearfix">
             <div class="row">

--- a/omod/src/main/webapp/resources/partials/source.html
+++ b/omod/src/main/webapp/resources/partials/source.html
@@ -1,16 +1,5 @@
 <div id="wide-sidebar" class="row">
-    <div class="col-lg-2">
-        <ul class="nav nav-tabs nav-stacked">
-            <li class="navigation-active"><a href="#/sources">Data Source</a></li>
-            <li><a href="#/configs">Setup Configurations</a></li>
-            <li><a href="#/queues">Queue Data</a></li>
-            <li><a href="#/registrations">Registrations</a></li>
-            <li><a href="#/forms">Muzima Forms</a></li>
-            <li><a href="#/errors">Error Data</a></li>
-            <li><a href="#/settings">Settings</a></li>
-            <li><a href="#/cohortDefinitions">Cohort Definitions</a></li>
-        </ul>
-    </div>
+    <side-navigation menu-item="source"></side-navigation>
     <div class="col-lg-8">
         <div ng-switch="mode">
             <div ng-switch-when="view">

--- a/omod/src/main/webapp/resources/partials/sources.html
+++ b/omod/src/main/webapp/resources/partials/sources.html
@@ -1,16 +1,5 @@
 <div id="wide-sidebar" class="row">
-    <div class="col-lg-2">
-        <ul class="nav nav-tabs nav-stacked">
-            <li class="navigation-active"><a href="#/sources">Data Source</a></li>
-            <li><a href="#/configs">Setup Configurations</a></li>
-            <li><a href="#/queues">Queue Data</a></li>
-            <li><a href="#/registrations">Registrations</a></li>
-            <li><a href="#/forms">Muzima Forms</a></li>
-            <li><a href="#/errors">Error Data</a></li>
-            <li><a href="#/settings">Settings</a></li>
-            <li><a href="#/cohortDefinitions">Cohort Definitions</a></li>
-        </ul>
-    </div>
+    <side-navigation menu-item="sources"></side-navigation>
     <div class="col-lg-8">
         <div class="clearfix">
             <div class="row">

--- a/omod/src/main/webapp/view.jsp
+++ b/omod/src/main/webapp/view.jsp
@@ -32,7 +32,9 @@
 <openmrs:htmlInclude file="/moduleResources/muzimacore/js/custom/controllers/ConfigController.js"/>
 <openmrs:htmlInclude file="/moduleResources/muzimacore/js/custom/controllers/SettingController.js"/>
 <openmrs:htmlInclude file="/moduleResources/muzimacore/js/custom/controllers/CohortDefinitionController.js"/>
+<openmrs:htmlInclude file="/moduleResources/muzimacore/js/custom/controllers/MergeController.js"/>
 <openmrs:htmlInclude file="/moduleResources/muzimacore/js/custom/directives/fileUpload.js"/>
+<openmrs:htmlInclude file="/moduleResources/muzimacore/js/custom/directives/sideNav.js"/>
 
 <h3><spring:message code="muzimacore.title"/></h3>
 <div class="bootstrap-scope" ng-app="muzimaCoreModule">


### PR DESCRIPTION
The user has the ability to either merge the incoming record or creating a new record.
In case the user chooses to merge the selected details will be updated on the existing patient.
Otherwise if the user chooses to create a new record, the system ensures the IDs if present are
not the same prompting the user to change if that is the case. Moreover choosing to create a new
patient record effectively means the system is no longer going to check for potential matches. This
is achieved by setting a flag on the payload.