### PR TITLE
DefaultAnnotationHandlerMapping end of Life

### DIFF
--- a/omod/src/main/resources/webModuleApplicationContext.xml
+++ b/omod/src/main/resources/webModuleApplicationContext.xml
@@ -3,11 +3,13 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
+       xmlns:mvc="http://www.springframework.org/schema/mvc"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
            http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
            http://www.springframework.org/schema/context
-           http://www.springframework.org/schema/context/spring-context-3.0.xsd">
-
-    <bean class="org.springframework.web.servlet.mvc.annotation.DefaultAnnotationHandlerMapping"/>
+           http://www.springframework.org/schema/context/spring-context-3.0.xsd
+           http://www.springframework.org/schema/mvc
+           http://www.springframework.org/schema/mvc/spring-mvc-3.0.xsd">
+    <mvc:annotation-driven/>
     <context:component-scan base-package="org.openmrs.module.muzima.web" />
 </beans>


### PR DESCRIPTION
Lately, I've been working on upgrading to openmrs platform v2.4.0. And I came across this error 👇🏾  during the upgrade process( on installing muzima core module to the upgraded AMRS - clearly, the aforementioned class is still been utilized by this module [here](https://github.com/muzima/openmrs-module-muzimacore/blob/master/omod/src/main/resources/webModuleApplicationContext.xml#L11) ):
```java
java.lang.ClassNotFoundException: org.springframework.web.servlet.mvc.annotation.DefaultAnnotationHandlerMapping
```
It's not a surprise since [DefaultAnnotationHandlerMapping](https://docs.spring.io/autorepo/docs/spring-framework/4.3.25.RELEASE/javadoc-api/org/springframework/web/servlet/mvc/annotation/DefaultAnnotationHandlerMapping.html) is already deprecated as of Spring 3.2, in favor of [RequestMappingHandlerMapping.](https://docs.spring.io/autorepo/docs/spring-framework/4.3.25.RELEASE/javadoc-api/org/springframework/web/servlet/mvc/method/annotation/RequestMappingHandlerMapping.html) So removing this class in the next (major) version - Spring 5 is completely understandable.

CC: @mssavai  @benamonya @sthaiya @samuelowino 